### PR TITLE
Persist dark mode

### DIFF
--- a/packages/next-app/components/Layout/Navbar.tsx
+++ b/packages/next-app/components/Layout/Navbar.tsx
@@ -1,32 +1,18 @@
-import { useEffect } from "react";
 import { Box, Button, Text, IconSun, useTheme, IconMoon } from "degen";
-import { Mode } from "degen/dist/types/tokens";
 import Link from "next/link";
 import Image from "next/image";
 import Wallet from "./Wallet";
 import styles from "./Navbar.module.css";
 import logoDark from "../../public/dark_tight.png";
 import logoLight from "../../public/light_tight.png";
+import cookieCutter from "cookie-cutter";
 
 const Navbar = () => {
   const { mode, setMode } = useTheme();
-  useEffect(() => {
-    const savedMode = window.localStorage.getItem("theme") as Mode;
-    if (savedMode) {
-      setTimeout(() => {
-        console.log("setting to", savedMode);
-        setMode(savedMode);
-      }, 1);
-    }
-  }, []);
-  // const initial = window?.localStorage.getItem("theme");
-  // console.log("initial", initial);
-
   const handleMode = () => {
     const newMode = mode === "light" ? "dark" : "light";
-    window.localStorage.setItem("theme", newMode);
+    cookieCutter.set("mode", newMode);
     setMode(newMode);
-    console.log("set theme to", newMode);
   };
 
   return (

--- a/packages/next-app/components/Layout/Navbar.tsx
+++ b/packages/next-app/components/Layout/Navbar.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react";
 import { Box, Button, Text, IconSun, useTheme, IconMoon } from "degen";
+import { Mode } from "degen/dist/types/tokens";
 import Link from "next/link";
 import Image from "next/image";
 import Wallet from "./Wallet";
@@ -8,9 +10,23 @@ import logoLight from "../../public/light_tight.png";
 
 const Navbar = () => {
   const { mode, setMode } = useTheme();
+  useEffect(() => {
+    const savedMode = window.localStorage.getItem("theme") as Mode;
+    if (savedMode) {
+      setTimeout(() => {
+        console.log("setting to", savedMode);
+        setMode(savedMode);
+      }, 1);
+    }
+  }, []);
+  // const initial = window?.localStorage.getItem("theme");
+  // console.log("initial", initial);
 
   const handleMode = () => {
-    setMode(mode == "light" ? "dark" : "light");
+    const newMode = mode === "light" ? "dark" : "light";
+    window.localStorage.setItem("theme", newMode);
+    setMode(newMode);
+    console.log("set theme to", newMode);
   };
 
   return (

--- a/packages/next-app/components/Layout/Navbar.tsx
+++ b/packages/next-app/components/Layout/Navbar.tsx
@@ -11,7 +11,7 @@ const Navbar = () => {
   const { mode, setMode } = useTheme();
   const handleMode = () => {
     const newMode = mode === "light" ? "dark" : "light";
-    cookieCutter.set("mode", newMode);
+    cookieCutter.set("mode", newMode, { path: "/" });
     setMode(newMode);
   };
 

--- a/packages/next-app/package.json
+++ b/packages/next-app/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.5.8",
+    "cookie-cutter": "^0.2.0",
     "cross-fetch": "^3.1.5",
     "degen": "^0.0.63",
     "ethers": "^5.5.4",

--- a/packages/next-app/pages/_app.tsx
+++ b/packages/next-app/pages/_app.tsx
@@ -5,8 +5,9 @@ import { ThemeProvider } from "degen";
 import "degen/styles";
 
 function MyApp({ Component, pageProps }: AppProps) {
+  console.log("pageProps", pageProps);
   return (
-    <ThemeProvider>
+    <ThemeProvider defaultMode={pageProps.mode}>
       <WagmiProvider>
         <Component {...pageProps} />
       </WagmiProvider>

--- a/packages/next-app/pages/_app.tsx
+++ b/packages/next-app/pages/_app.tsx
@@ -5,7 +5,6 @@ import { ThemeProvider } from "degen";
 import "degen/styles";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  console.log("pageProps", pageProps);
   return (
     <ThemeProvider defaultMode={pageProps.mode}>
       <WagmiProvider>

--- a/packages/next-app/pages/_app.tsx
+++ b/packages/next-app/pages/_app.tsx
@@ -6,7 +6,7 @@ import "degen/styles";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <ThemeProvider defaultMode={pageProps.mode}>
+    <ThemeProvider defaultMode={pageProps.mode || "light"}>
       <WagmiProvider>
         <Component {...pageProps} />
       </WagmiProvider>

--- a/packages/next-app/pages/calls/[id].tsx
+++ b/packages/next-app/pages/calls/[id].tsx
@@ -1,4 +1,5 @@
-import type { GetServerSideProps, GetStaticPaths, GetStaticProps } from "next";
+import type { GetServerSideProps } from "next";
+import cookieCutter from "cookie-cutter";
 
 import { getAllCallsForFunds, getCallForFundsByID } from "../../graph/functions";
 import { CallForFunding } from "../../graph/loudverse-graph-types";
@@ -13,20 +14,10 @@ const Call = ({ call }: { call: CallForFunding }) => {
   );
 };
 
-// export const getStaticPaths: GetStaticPaths = async () => {
-//   const allCalls = await getAllCallsForFunds();
-//   const paths = [];
-
-//   allCalls.forEach((call, i) => {
-//     paths.push({ params: { id: `${i}` } });
-//   });
-
-//   return { paths, fallback: true };
-// };
-
 export const getServerSideProps: GetServerSideProps = async context => {
   const { id } = context.params;
   const allCalls = await getAllCallsForFunds();
+  const cookie = cookieCutter(context.req.headers);
 
   let call = allCalls[Number(id)];
   if (call === undefined) {
@@ -40,6 +31,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   return {
     props: {
       call: call,
+      mode: cookie.get("mode"),
     },
   };
 };

--- a/packages/next-app/pages/calls/[id].tsx
+++ b/packages/next-app/pages/calls/[id].tsx
@@ -31,7 +31,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   return {
     props: {
       call: call,
-      mode: cookie.get("mode"),
+      mode: cookie.get("mode") || null,
     },
   };
 };

--- a/packages/next-app/pages/calls/create.tsx
+++ b/packages/next-app/pages/calls/create.tsx
@@ -16,7 +16,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   return {
     props: {
-      mode: cookie.get("mode"),
+      mode: cookie.get("mode") || null,
     },
   };
 };

--- a/packages/next-app/pages/calls/create.tsx
+++ b/packages/next-app/pages/calls/create.tsx
@@ -1,4 +1,5 @@
-import type { NextPage } from "next";
+import type { GetServerSideProps, NextPage } from "next";
+import cookieCutter from "cookie-cutter";
 import PageWrapper from "../../components/Layout/PageWrapper";
 import NewProjectForm from "../../components/Forms/NewProjectForm"; // change
 
@@ -8,6 +9,16 @@ const Create: NextPage = () => {
       <NewProjectForm />
     </PageWrapper>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  const cookie = cookieCutter(context.req.headers);
+
+  return {
+    props: {
+      mode: cookie.get("mode"),
+    },
+  };
 };
 
 export default Create;

--- a/packages/next-app/pages/calls/index.tsx
+++ b/packages/next-app/pages/calls/index.tsx
@@ -1,6 +1,6 @@
-import type { GetServerSideProps, GetStaticProps, NextPage } from "next";
-import Head from "next/head";
+import type { GetServerSideProps } from "next";
 import { Box, Stack, Text, Heading } from "degen";
+import cookieCutter from "cookie-cutter";
 
 import { getAllCallsForFunds } from "../../graph/functions";
 import { CallForFunding } from "../../graph/loudverse-graph-types";
@@ -41,12 +41,14 @@ const Calls = ({ calls }: { calls: CallForFunding[] }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getServerSideProps: GetServerSideProps = async context => {
   const allCalls = await getAllCallsForFunds();
+  const cookie = cookieCutter(context.req.headers);
 
   return {
     props: {
       calls: allCalls,
+      mode: cookie.get("mode"),
     },
   };
 };

--- a/packages/next-app/pages/calls/index.tsx
+++ b/packages/next-app/pages/calls/index.tsx
@@ -48,7 +48,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   return {
     props: {
       calls: allCalls,
-      mode: cookie.get("mode"),
+      mode: cookie.get("mode") || null,
     },
   };
 };

--- a/packages/next-app/pages/index.tsx
+++ b/packages/next-app/pages/index.tsx
@@ -1,21 +1,9 @@
 import type { GetServerSideProps } from "next";
 import Head from "next/head";
 import Image from "next/image";
-import Link from "next/link";
+import { Box, Heading, IconBookOpen, IconEth, IconHand, IconPlug, IconUsersSolid, Text, useTheme } from "degen";
 import cookieCutter from "cookie-cutter";
-import {
-  Box,
-  Button,
-  Heading,
-  IconBookOpen,
-  IconCollection,
-  IconEth,
-  IconHand,
-  IconPlug,
-  IconUsersSolid,
-  Text,
-  useTheme,
-} from "degen";
+
 import CtaBar from "../components/Layout/CtaBar";
 import PageWrapper from "../components/Layout/PageWrapper";
 import logoDark from "../public/loudverse_logo_dark.png";

--- a/packages/next-app/pages/index.tsx
+++ b/packages/next-app/pages/index.tsx
@@ -134,7 +134,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   return {
     props: {
       calls: allCalls,
-      mode: cookie.get("mode"),
+      mode: cookie.get("mode") || null,
     },
   };
 };

--- a/packages/next-app/pages/index.tsx
+++ b/packages/next-app/pages/index.tsx
@@ -1,7 +1,8 @@
-import type { GetStaticProps, NextPage } from "next";
+import type { GetServerSideProps } from "next";
 import Head from "next/head";
 import Image from "next/image";
 import Link from "next/link";
+import cookieCutter from "cookie-cutter";
 import {
   Box,
   Button,
@@ -138,12 +139,14 @@ const Home = ({ calls }: { calls: CallForFunding[] }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getServerSideProps: GetServerSideProps = async context => {
   const allCalls = await getAllCallsForFunds();
+  const cookie = cookieCutter(context.req.headers);
 
   return {
     props: {
       calls: allCalls,
+      mode: cookie.get("mode"),
     },
   };
 };

--- a/packages/next-app/pages/users/[id].tsx
+++ b/packages/next-app/pages/users/[id].tsx
@@ -1,5 +1,5 @@
-import type { GetServerSideProps, GetStaticPaths, GetStaticProps, NextPage } from "next";
-import Head from "next/head";
+import type { GetServerSideProps } from "next";
+import cookieCutter from "cookie-cutter";
 import FullPageUser from "../../components/FullPageUser";
 import PageWrapper from "../../components/Layout/PageWrapper";
 import { User } from "../../graph/loudverse-graph-types";
@@ -15,29 +15,20 @@ const User = ({ user }: { user: User }) => {
   );
 };
 
-// export const getStaticPaths: GetStaticPaths = async () => {
-//   const allUsers = await getAllUsers();
-//   const paths = [];
-
-//   allUsers.forEach(user => {
-//     paths.push({ params: { id: `${user.id}` } });
-//   });
-
-//   return { paths, fallback: true };
-// };
-
 export const getServerSideProps: GetServerSideProps = async context => {
   const { id } = context.params;
   const user = await getUserByID(id as string);
+  const cookie = cookieCutter(context.req.headers);
 
   if (user) {
     return {
       props: {
         user: user,
+        mode: cookie.get("mode"),
       },
     };
   }
-  return { props: { notFound: true } };
+  return { props: { notFound: true, mode: cookie.get("mode") } };
 };
 
 export default User;

--- a/packages/next-app/pages/users/[id].tsx
+++ b/packages/next-app/pages/users/[id].tsx
@@ -24,11 +24,11 @@ export const getServerSideProps: GetServerSideProps = async context => {
     return {
       props: {
         user: user,
-        mode: cookie.get("mode"),
+        mode: cookie.get("mode") || null,
       },
     };
   }
-  return { props: { notFound: true, mode: cookie.get("mode") } };
+  return { props: { notFound: true, mode: cookie.get("mode") || null } };
 };
 
 export default User;

--- a/packages/next-app/pages/users/index.tsx
+++ b/packages/next-app/pages/users/index.tsx
@@ -1,13 +1,24 @@
 import { Box } from "degen";
-import type { NextPage } from "next";
+import type { GetServerSideProps, NextPage } from "next";
+import cookieCutter from "cookie-cutter";
 import PageWrapper from "../../components/Layout/PageWrapper";
 
 const Users: NextPage = () => {
   return (
     <PageWrapper>
-      <Box>You must view a specific user</Box>
+      <Box color="foreground">You must view a specific user</Box>
     </PageWrapper>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  const cookie = cookieCutter(context.req.headers);
+
+  return {
+    props: {
+      mode: cookie.get("mode"),
+    },
+  };
 };
 
 export default Users;

--- a/packages/next-app/pages/users/index.tsx
+++ b/packages/next-app/pages/users/index.tsx
@@ -16,7 +16,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   return {
     props: {
-      mode: cookie.get("mode"),
+      mode: cookie.get("mode") || null,
     },
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6503,6 +6503,11 @@ convert-source-map@1.X, convert-source-map@^1.5.1, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-cutter@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/cookie-cutter/-/cookie-cutter-0.2.0.tgz#5988f598b68c060a00ec8524ad6e6aa193e72244"
+  integrity sha1-WYj1mLaMBgoA7IUkrW5qoZPnIkQ=
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"


### PR DESCRIPTION
Trickier than expected (set on load didn't work, immediately after load was jarring, local storage threw an untraceable error).

Ended up setting in the cookie and retrieving with getServerSideProps. I think this is the most "Next" way except that it should ideally be factored out into a function that gets the props you need every time. But mode is the only one right now, so this is easiest to read.