### PR TITLE
disable apollo cache

### DIFF
--- a/packages/next-app/graph/index.ts
+++ b/packages/next-app/graph/index.ts
@@ -1,11 +1,23 @@
 import "cross-fetch/polyfill";
-import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { ApolloClient, DefaultOptions, InMemoryCache } from "@apollo/client";
 
 const APIURL = "https://api.thegraph.com/subgraphs/name/nickadamson/loudverse-polygon";
+const cache = new InMemoryCache();
+const defaultOptions: DefaultOptions = {
+  watchQuery: {
+    fetchPolicy: "no-cache",
+    errorPolicy: "ignore",
+  },
+  query: {
+    fetchPolicy: "no-cache",
+    errorPolicy: "all",
+  },
+};
 
 const LoudverseClient = new ApolloClient({
   uri: APIURL,
-  cache: new InMemoryCache(),
+  cache: cache,
+  defaultOptions: defaultOptions,
 });
 
 export default LoudverseClient;


### PR DESCRIPTION
even when the subgraph finally catches up, apollo's cache is still causing a massive delay in the time it takes for changes to appear. no-cache for now